### PR TITLE
Rename infrahouse source to 50-infrahouse.list

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -36,7 +36,7 @@ KEYRING_DIR="/etc/apt/keyrings"
 KEYRING_PATH="${KEYRING_DIR}/infrahouse.gpg"
 REPO_HOST="release-${UBUNTU_CODENAME}.infrahouse.com"
 REPO_URL="https://${REPO_HOST}/"
-REPO_LIST="/etc/apt/sources.list.d/infrahouse.list"
+REPO_LIST="/etc/apt/sources.list.d/50-infrahouse.list"
 
 
 install -d -m 0755 "${KEYRING_DIR}"


### PR DESCRIPTION
With the "50" prefix a user has more control over the sources order when user's and infrahouse's repos are configured on the same system.
The cloud-init module uses `50-infrahouse.list`, so should packer.
