### PR TITLE
Clear systemd timer stamps and set a global dpkg lock timeout

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -8,6 +8,14 @@ declare -A fingerprints=(
   [noble]="A627 B776 0019 0BA5 1B90  3453 D37A 181B 689A D619"
 )
 
+configure_apt_lock_timeout() {
+    # Puppet's Package provider, cloud-init and the AWS agents (guardduty,
+    # inspector) all shell out to apt-get without options, so a global drop-in
+    # is the only place that makes them wait for the dpkg lock instead of
+    # failing outright when something else holds it.
+    echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout
+}
+
 cleanup_logs() {
     cloud-init clean --logs
     truncate -s0 /var/log/syslog 2>/dev/null || true
@@ -21,6 +29,21 @@ cleanup_system_ids() {
     rm -f /var/lib/dbus/machine-id || true
     rm -f /home/ubuntu/.bash_history || true
 }
+
+cleanup_timer_stamps() {
+    # Persistent=true timers record their last trigger here. If these survive
+    # into the snapshot, every launched instance sees a last-trigger of AMI
+    # build time and systemd fires a catch-up run shortly after boot -- for
+    # apt-daily-upgrade that means an unattended-upgrade holding the dpkg lock
+    # during provisioning. Stock Ubuntu ships this directory empty and systemd
+    # recreates it on first boot, so there is nothing to restore.
+    # Timers are stopped first so none of them can re-stamp in the window
+    # between this script exiting and packer powering the instance off.
+    systemctl stop '*.timer' 2>/dev/null || true
+    rm -rf /var/lib/systemd/timers/ || true
+}
+
+configure_apt_lock_timeout
 
 apt-get update
 apt-get -y upgrade
@@ -85,3 +108,4 @@ rm -rf /var/lib/apt/lists/*
 
 cleanup_logs
 cleanup_system_ids
+cleanup_timer_stamps


### PR DESCRIPTION
Fixes #20

## What

Two changes to `provision.sh`:

**1. `cleanup_timer_stamps()` — the fix for #20.**

The build instance boots stock Ubuntu with `apt-daily.timer` and `apt-daily-upgrade.timer` enabled, so systemd stamps `/var/lib/systemd/timers/` at boot and those stamps get baked into the snapshot. Both timers ship `Persistent=true`, so every launched instance loads a last-trigger of AMI build time and schedules a *catch-up* run relative to boot — jittered by `RandomizedDelaySec` (1h for `apt-daily-upgrade`) instead of firing at the next 06:00. When that draw lands inside the provisioning window, the catch-up `unattended-upgrade` holds `/var/lib/dpkg/lock-frontend` and every `Package` resource Puppet evaluates afterwards fails.

Removing the directory restores stock behaviour: with no stamp file, systemd touches a fresh one at unit start and leaves `last_trigger` unset, so there is no backlog. Nothing needs to be restored.

Timers are stopped before the `rm` so none of them can re-stamp in the window between the script exiting and packer powering the instance off. Stopping is runtime-only — the units stay `enabled` and start normally on the next boot.

**2. `/etc/apt/apt.conf.d/99-lock-timeout` with `DPkg::Lock::Timeout "300";`.**

Puppet's `Package` provider, cloud-init and the AWS agents all shell out to `apt-get` with no options, so a global drop-in is the only place that makes them wait for the lock rather than fail immediately. This is deliberately in the AMI rather than in `puppet-code`: it also covers the `amazon-guardduty-agent` (~T+50s) and `inspectorssmplugin` (~T+85s) dpkg installs that the timer-stamp fix does not address, and it applies to every consumer of the image. Puppet is free to manage the file too.

Side benefit: the drop-in is installed before the first `apt-get update`, so the build itself is also protected from `unattended-upgrades` racing it on the stock base image.

## Not included

Removing `/var/lib/systemd/random-seed` was considered and dropped — `systemd-random-seed.service` has `ExecStop=systemd-random-seed save`, so the file is rewritten during packer's shutdown and deleting it here would be a no-op.

## Verification

Launch from the rebuilt AMI with no user-data:

```bash
ls -la --time-style=full-iso /var/lib/systemd/timers/
systemctl show apt-daily-upgrade.timer -p LastTriggerUSec -p NextElapseUSecRealtime
apt-config dump | grep -i 'lock::timeout'
```

Expected: no `stamp-*` older than the current boot, `LastTriggerUSec=` empty, `NextElapseUSecRealtime` at the next 06:00 (+ up to 1h jitter) rather than within an hour of boot, and `DPkg::Lock::Timeout "300";`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)