### PR TITLE
Pin the AMI build to a development environment runner

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -26,7 +26,11 @@ env:
 jobs:
   build:
     name: 'Build AMI'
-    runs-on: ["self-hosted", "Linux", "noble"]
+    # Packer builds into the VPC in 303467602807 and reaches the source instance
+    # over SSH, so the job has to land on a runner in that account. Without the
+    # environment label the org's production runners in 493370826424 match too,
+    # and the build dies waiting for SSH before any provisioner runs.
+    runs-on: ["self-hosted", "Linux", "noble", "environment:development"]
 
     defaults:
       run:


### PR DESCRIPTION
## Why

`runs-on` was `["self-hosted", "Linux", "noble"]`, which the org's **production** runners in `493370826424` satisfy just as well as the CICD runners in `303467602807`. Packer launches its source instance into the VPC in `303467602807` and connects over SSH, so a job landing on a production runner has no route to the instance:

```
Waiting for SSH to become available...   13:50:47
Timeout waiting for SSH.                 13:55:47
```

That's what killed [run 30636064342](https://github.com/infrahouse/infrahouse-ubuntu-pro/actions/runs/30636064342) — before any provisioner ran, so nothing to do with the `provision.sh` change merged just ahead of it.

## What

Adds `environment:development` to `runs-on`. The `infrahouse/actions-runner/aws` module labels instances with `environment:<environment>`, and `aws-control-303467602807` sets `environment = "development"` in `locals.tf`, so this restricts the job to runners in the build account.

Depends on infrahouse/aws-control-303467602807#260 (revert of the CICD runner decomm) being applied — without those runners nothing matches the new label and the job queues rather than failing fast.

## Verify

Dispatch with `force_rebuild: true` and confirm the job lands on an `ip-10-0-*` runner in `303467602807` and reaches `Provisioning with shell script`. That same run is also the first real exercise of the timer-stamp cleanup from #21 — every scheduled run since 07-14 has been a ~20s no-op skip, since `packer-build.py:116` only builds when the base AMI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)